### PR TITLE
Redirect fast lane to download view and update text

### DIFF
--- a/html/static/css/base.css
+++ b/html/static/css/base.css
@@ -58,7 +58,10 @@ h1 span {
 }
 
 div.section {
-  margin: 80px 0 140px 0;
+  margin: 40px 0 40px 0;
+}
+div.section#manual-install {
+  margin-top: 200px;
 }
 
 div.section h2 {

--- a/html/templates/base.html
+++ b/html/templates/base.html
@@ -5,7 +5,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>Custom Installer Builder</title>
 
-  <link rel="stylesheet" href="{{ MEDIA_URL }}css/base.css" />
+  <link rel="stylesheet" href="{{ MEDIA_URL }}css/base.css?q=20170313" />
 	<script type="text/javascript" src="{{ MEDIA_URL }}js/base.js"></script>
 
 	<!-- jQuery + plugins -->

--- a/html/templates/download_installers.html
+++ b/html/templates/download_installers.html
@@ -68,25 +68,26 @@
 </div> -->
 {% endcomment %}
 
+
+
 <div class="section">
-  <h2>Get Sensibility Testbed from Google Play</h2>
-    <p>Use below button (or QRcode) to install the app from Google Play. That's really all you need to get Sensibility Testbed onto your phone. Once you start the app, everything will be setup for you. All that's left is to download your experimenter keys (next section) and you are ready to perform experiments!</p>
-    <p class="note">Note: Sensibility Testbed currently only runs on ARM powered devices with Android 5 (&quot;Lollipop&quot;) or higher. We are striving to support more platforms in the future!</p>
-    <div class="app-playstore-url center">
-      <div class="qrcode"></div>
-      <a class="button" href="">Download app from Google Play</a>
-    </div>
+  <p>Sensibility Testbed runs in a sandboxed environment on your Android device. In order to conduct your sensor experiments you need a pair of cryptographic keys that is associated with your device. But don't worry, by browsing to this page you have already created your very own custom Sensibility installer and the according keys. All that's left to do is to click on the right buttons below. <br>Learn more about Sensibility Testbed by reading the <a href="https://github.com/SensibilityTestbed/instructions/blob/master/README.md">usage guides</a>.</p>
+
+  {% if fast_lane %}
+    <p>Note that the keys below are only available in this browser session, if the session expires or you open the URL on a different device, we will not let you download the keys anymore, for your own good!</p>
+  {% else %}
+    <p>For security reasons we don't show the cryptographic keys associated with the custom installer on this page. If you haven't downloaded your keys earlier, you should start over, by going back to the <a href="{{request.scheme}}://{{request.get_host}}{% url 'fastlane_page' %}">custom installer builder fast lane</a>.</p>
+  {% endif %}
 </div>
 
 {% comment %}
 We only show the keys if this is a fast_lane page and the custom installer
 was created in this session.
 {% endcomment %}
-
 {% if fast_lane and user_built %}
 <div class="section">
   <h2>Download Experimenter Keys</h2>
-  <p>We have generated ZIP archives of cryptographic keys associated with your app installation. You need these keys to access the sandbox running on your phone from the experimenter interface. More on that later. For now, just click on the buttons below to download the keys to your computer.</p>
+  <p>Please download these keys to your laptop or desktop computer! You will need them in order to run experiments on your device using <a href="https://github.com/SensibilityTestbed/instructions/blob/master/Setup.md">seash</a>.</p>
   <div class="center">
     <span id="private_keys">
       <a id="download_private_keys" class="button key {% if keys_downloaded.private %}checked{% endif %}" href="{% url 'download-keys' build_id=build_id key_type='private' %}">Download private keys</a>
@@ -100,6 +101,16 @@ was created in this session.
 
 
 <div class="section">
+  <h2>Get Sensibility Testbed from Google Play</h2>
+    <p>Please use below button or QR code to install the app from Google Play. By using this link we can tell Google Play to serve you your custom Sensibility installation.</p>
+    <div class="app-playstore-url center">
+      <div class="qrcode"></div>
+      <a class="button" href="">Download app from Google Play</a>
+    </div>
+</div>
+
+
+<div id="manual-install" class="section">
   <h2>Installation Alternative (manual)</h2>
   <p>For development purposes we also provide a manual installation procedure. This includes installing the app from an .APK file, and downloading and installing the custom installer from a URL specified in the app. Perform the following steps on your Android device:</p>
 
@@ -112,7 +123,6 @@ was created in this session.
     <li>Tap the &quot;Install&quot; button to benchmark your device and configure Sensibility Testbed's cryptography for your device. Depending on the speed of your device, the process can take a minute or two to finish.</li>
     <li>Finally, tap the &quot;Start&quot; button to start the Sensibility Testbed node manager.</li>
   </ol>
-
   <div class="center">
     <div class="app-apk-url half">
       <h3>.APK file URL</h3>

--- a/html/templates/download_installers.html
+++ b/html/templates/download_installers.html
@@ -48,9 +48,13 @@
 {% endblock %}
 
 {% block content %}
-<!-- Un-Django-comment the block below to style the page differently depending on whether the person that built this installer sees it (`user_built==True`), or the person comes in via a shared link. We currently disable this to always show a QR code for this page. -->
+
 {% comment %}
-<div class="section center">
+ Un-Django-and-un-HTML-comment the block below to style the page differently depending on whether the person that built this installer sees it (`user_built==True`), or the person comes in via a shared link. We currently disable this to always show a QR code for this page.
+ {% endcomment %}
+
+{% comment %}
+<!-- <div class="section center">
   {% if user_built %}
     <h2>Your installers are ready!</h2>
     <p>Bookmark this page to come back later, or share this URL with others:</p>
@@ -61,9 +65,8 @@
     <h2>Thanks for contributing!</h2>
     <p>The installers below have been customized by a Seattle user. By running these installers, 10% of your computing resources will be donated to an experiment being run by that user.</p>
   {% endif %}
-</div>
+</div> -->
 {% endcomment %}
-
 
 <div class="section">
   <h2>Get Sensibility Testbed from Google Play</h2>
@@ -75,7 +78,12 @@
     </div>
 </div>
 
-{% if fast_lane %}
+{% comment %}
+We only show the keys if this is a fast_lane page and the custom installer
+was created in this session.
+{% endcomment %}
+
+{% if fast_lane and user_built %}
 <div class="section">
   <h2>Download Experimenter Keys</h2>
   <p>We have generated ZIP archives of cryptographic keys associated with your app installation. You need these keys to access the sandbox running on your phone from the experimenter interface. More on that later. For now, just click on the buttons below to download the keys to your computer.</p>

--- a/html/views.py
+++ b/html/views.py
@@ -491,6 +491,8 @@ def download_installers_page(request, build_id):
       step = 'installers'
       user_built = True
 
+      # TODO: For better user feedback it would be nice to know if this is
+      # a fast_lane_build even if we don't have the session.
       if 'fast_lane_build' in request.session['build_results'][build_id]:
         fast_lane = True
 

--- a/settings_base.py
+++ b/settings_base.py
@@ -41,7 +41,7 @@ TEMPLATES = [
                 # Adds 'TIME_ZONE' to template context
                 # 'django.template.context_processors.tz',
                 # Adds 'request' to template context
-                # 'django.template.context_processors.request',
+                'django.template.context_processors.request',
                 # Adds 'messages' and 'DEFAULT_MESSAGE_LEVELS' to context
                 #'django.contrib.messages.context_processors.messages',
             ],


### PR DESCRIPTION
Modifies the fast lane view to redirect to the download view using an existing or newly created build id to have the unique URL in the browser's address bar.

In the download view we now check if the build was a fast lane build and if it was built in the same session to know if we also have to render the download keys section of the template.

Further changes to the download template include:
- Updates help texts to be less instructive (that's what the instructions should do) and rather give some context
- Adds links to instructions and fastlane page
- Shows different text if keys are shown or not (user_built)
- Re-adds request middleware to load the full path in a template
- Changes vertical spacing between sections (margin top/bottom)
- Adds static cache buster for base.css
